### PR TITLE
Updated Examples to reflect default separater, instead of custom one

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Sometimes it is necesarry to config manage .yml files.
   - name: manage yaml files
     yedit:
       src: /tmp/test.yaml
-      key: a#b#c
+      key: a.b.c
       value:
         d:
           e:
@@ -55,7 +55,7 @@ Sometimes it is necesarry to config manage .yml files.
     yedit:
       src: /tmp/test.yaml
       state: list
-      key: a#b#c#d#e#f
+      key: a.b.c.d.e.f
     register: yeditout
   - debug: var=yeditout
 ----

--- a/library/yedit.py
+++ b/library/yedit.py
@@ -152,7 +152,7 @@ EXAMPLES = '''
 - name: insert simple key, value
   yedit:
     src: somefile.yml
-    key: a#b#c
+    key: a.b.c
     value: d
     state: present
 # Results:
@@ -165,9 +165,9 @@ EXAMPLES = '''
   yedit:
     src: somefile.yml
     edits:
-    - key: a#b#c
+    - key: a.b.c
       value: d
-    - key: a#b#c#d
+    - key: a.b.c.d
       value: e
     state: present
 # Results:


### PR DESCRIPTION
The default separator is set to '.', however, the examples in README.md and in yedit.py use '#' instead.

```
  separator:
    description:
    - The separator being used when parsing strings.
    required: false
    default: '.'
    aliases: []
```