### PR TITLE
Allow the key value to be a empty string

### DIFF
--- a/library/yedit.py
+++ b/library/yedit.py
@@ -943,7 +943,7 @@ def main():
         key_error = False
         edit_error = False
 
-        if module.params['key'] in [None]:
+        if module.params['key'] is None:
             key_error = True
 
         if module.params['edits'] in [None, []]:

--- a/library/yedit.py
+++ b/library/yedit.py
@@ -943,7 +943,7 @@ def main():
         key_error = False
         edit_error = False
 
-        if module.params['key'] in [None, '']:
+        if module.params['key'] in [None]:
             key_error = True
 
         if module.params['edits'] in [None, []]:


### PR DESCRIPTION
The documentation states that you can pass a empty string `''` for the key value to append to the root of the yaml file.
```
  key:
    description:
    - The path to the value you wish to modify. Emtpy string means the top of
    - the document
```
This change allows empty string to be passed in.
