### PR TITLE
B #84: fix key validation

### DIFF
--- a/library/yedit.py
+++ b/library/yedit.py
@@ -210,7 +210,7 @@ class YeditException(Exception):
 # pylint: disable=too-many-public-methods,too-many-instance-attributes
 class Yedit(object):
     ''' Class to modify yaml files '''
-    re_valid_key = r"(((\[-?\d+\])|([0-9a-zA-Z%s/_-]+)).?)+$"
+    re_valid_key = r"(((\[-?\d+\])|([0-9a-zA-Z{}/_-]+)).?)+$"
     re_key = r"(?:\[(-?\d+)\])|([0-9a-zA-Z{}/_-]+)"
     com_sep = set(['.', '#', '|', ':'])
 


### PR DESCRIPTION
`%s` is not recognized by `str.format()`