### PR TITLE
Add ability to edit files in read-only directories.

### DIFF
--- a/library/yedit.py
+++ b/library/yedit.py
@@ -183,6 +183,7 @@ import json   # noqa: F401
 import os  # noqa: F401
 import re  # noqa: F401
 import shutil  # noqa: F401
+import tempfile  # noqa: F401
 import time  # noqa: F401
 
 try:
@@ -403,16 +404,17 @@ class Yedit(object):
     def _write(filename, contents):
         ''' Actually write the file contents to disk. This helps with mocking. '''
 
-        tmp_filename = filename + '.yedit'
+        tmp_filename = tempfile.NamedTemporaryFile(mode='w', delete=False)
 
-        with open(tmp_filename, 'w') as yfd:
+        with open(tmp_filename.name, 'w') as yfd:
             fcntl.flock(yfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             yfd.write(contents)
             yfd.flush()  # flush internal buffers
             os.fsync(yfd.fileno())  # ensure buffer content reached disk
             fcntl.flock(yfd, fcntl.LOCK_UN)
+        tmp_filename.close()
 
-        os.rename(tmp_filename, filename)
+        shutil.move(tmp_filename.name, filename)
         # While the rename is atomic, we also need to ensure, that the updated
         # directory entry has reached the disk too.
         # NOTE: this might fail on Windows systems.


### PR DESCRIPTION
For example, we have access to only one file in /etc/ directory and would like to modify it.
Original library try to create a temp file inside this directory and fails because we have not enough permissions.

This PR modify original behavior to create a temp file for write in temp directory and after successfully write move in to proper location.