### PR TITLE
Set 'value' type to noop validator

### DIFF
--- a/library/yedit.py
+++ b/library/yedit.py
@@ -946,6 +946,10 @@ def json_roundtrip_clean(js):
 def main():
     ''' ansible oc module for secrets '''
 
+    # Noop validator, as the type can be flexible.
+    def validate_value(value, *args):
+        return value
+
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', type='str',
@@ -955,7 +959,7 @@ def main():
             content=dict(default=None),
             content_type=dict(default='yaml', choices=['yaml', 'json']),
             key=dict(default='', type='str'),
-            value=dict(),
+            value=dict(type=validate_value),
             value_type=dict(default='', type='str'),
             update=dict(default=False, type='bool'),
             append=dict(default=False, type='bool'),


### PR DESCRIPTION
If the type of an argument is not set, ansible defaults to treating it
as a string. As such it gets run through a validator that converts the
value to a string via str().

In the case of 'value' being `null`, or perhaps a dict or list that
contained `null`, the conversion via str() would cause the python native
`None` to be passed to this module, which when parsed through
yaml.safe_load() in parse_value(), would return the string `'None'`.

To fix this, we set the type of 'value' to a noop validator, as the type
may vary and we don't want ansible to perform any conversion.