### PR TITLE
yedit.py temprary fix for deprecated ruamel.yaml functions

### DIFF
--- a/library/yedit.py
+++ b/library/yedit.py
@@ -194,10 +194,10 @@ import re  # noqa: F401
 import shutil  # noqa: F401
 import time  # noqa: F401
 
-try:
-    import ruamel.yaml as yaml  # noqa: F401
-except ImportError:
-    import yaml  # noqa: F401
+#try:
+#    import ruamel.yaml as yaml  # noqa: F401
+#except ImportError:
+import yaml  # noqa: F401
 
 from ansible.module_utils.basic import AnsibleModule
 


### PR DESCRIPTION
ruamel.yaml no longer exposes load and safe_load methods. commented 3 lines from line 189 to disable ruamel.yaml and use default yaml